### PR TITLE
MyIP script: support both IPv4 and IPv6

### DIFF
--- a/MyIP/whatsmyip.sh
+++ b/MyIP/whatsmyip.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dig +short myip.opendns.com @resolver1.opendns.com
+dig +short myip.opendns.com ANY @resolver1.opendns.com


### PR DESCRIPTION
If the user's system has IPv6 connectivity, the request to the OpenDNS resolver will be made over IPv6 by default, and thus the response will contain an AAAA record instead of an A one.
`dig` defaults to querying for an A record, so this combination will lead to an empty result from the script.

The `ANY` query type does not guarantee the presence of A or AAAA records (as per [RFC8482](https://tools.ietf.org/html/rfc8482)), but OpenDNS currently serves A or AAAA as appropriate, so this will provide a simple workaround.